### PR TITLE
Allow mdlxoptimizer to keep entries with 2 keyframes

### DIFF
--- a/clients/mdlxoptimizer/index.ts
+++ b/clients/mdlxoptimizer/index.ts
@@ -87,7 +87,7 @@ function optimizeAnimation(model: MdlxModel, animation: Animation) {
   const finalEntries: Entry[] = [];
 
   // Now that all of the entries are valid in sequences, we can check for values.
-  if (keptEntries.length > 2) {
+  if (keptEntries.length >= 2) {
     for (let i = 0, l = keptEntries.length; i < l; i++) {
       const entry = keptEntries[i];
       const frame = entry[FRAME];


### PR DESCRIPTION
Someone mentioned this mdlx optimizer to me, and I was looking at it and I tried the Druid of the Claw model. But the model breaks and no longer opens in the World Editor after putting it through this optimizer. I traced the bug to the translation block on the Druid of the Claw helper shown below:

```
Helper "DoC_Dummy" {
	ObjectId 57,
	Translation 2 {
		Linear,
		46667: { 0, 0, 0 },
		106667: { 0, 0, -52.5848 },
	}
	Scaling 4 {
		Linear,
		6667: { 1, 1, 1 },
		7467: { 1, 1, 1 },
		7633: { 0.746269, 0.746269, 0.746269 },
		8167: { 1, 1, 1 },
	}
}
```

If we look, this translation block has 2 keyframes, but they are meaningful and important and cause this Night Elf to sink into the ground during his "Decay Flesh" animation. So, I created this pull request to allow animation timelines with only 2 keyframes to be retained during the optimization.

Notably, I have not done the necessary testing on this pull request to determine that this case does not affect other stuff. So, I understand if this pull request is slow to review or merge. But I think it would be nice to get the optimizer not to break models.

As a possible further improvement, a general case check could be added to the optimizer to eliminate any animation timeline with 0 keyframes in the resulting output model, because timelines in that format are typically accepted by our fan-made MDX software but are typically rejected by the Warcraft III game engine.  